### PR TITLE
Removed double Content-Type workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ The current list of such functions is:
 
 - `NetHSM.set_key_certificate()` : `/keys/{KeyID}/cert`
 - `NetHSM.set_certificate()` : `/config/tls/cert.pem`
-- `NetHSM.update()`: `/system/update`, manual deserialization because the content-type header is sent twice, see [#245 on the NetHSM repo](https://git.nitrokey.com/nitrokey/nethsm/nethsm/-/issues/245)
 
 ### Publishing a new version
 
@@ -108,4 +107,4 @@ docker run -v "$PWD:/nethsm" -e FLIT_ROOT_INSTALL=1 -e TEST_MODE=ci -it --entryp
 
 > Be aware this command will create files owned by root in your working directory.
 
-This CI mode manually start and stops the necessary processes to run a NetHSM instance, due to its design it may brake when the container image is updated.
+This CI mode manually start and stops the necessary processes to run a NetHSM instance, due to its design it may break when the container image is updated.

--- a/nethsm/__init__.py
+++ b/nethsm/__init__.py
@@ -1311,12 +1311,7 @@ class NetHSM:
 
     def update(self, image: BufferedReader):
         try:
-            # Currently the deserialisation doesn't work because of a bug where the api sends the content-type header twice
-            # https://git.nitrokey.com/nitrokey/nethsm/nethsm/-/issues/245
-
-            response = self.get_api().system_update_post(
-                body=image, skip_deserialization=True
-            )
+            response = self.get_api().system_update_post(body=image)
         except Exception as e:
             _handle_exception(
                 e,

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -70,8 +70,11 @@ class KeyfenderDockerManager(KeyfenderManager):
                     pass
             sleep(1)
 
+        repository, tag = C.IMAGE.split(":")
+        image = client.images.pull(repository, tag=tag)
+
         container = client.containers.run(
-            C.IMAGE,
+            image,
             "",
             ports={"8443": 8443},
             remove=True,


### PR DESCRIPTION
By fixing the bug that the HTTP header Content-Type is sent twice for the /system/update API call the corresponding workaround plus its mention in the README file, can be removed.

This closes #40 