### PR TITLE
Adjust API delete certificate error message & status code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ nethsm-client: nethsm-api.yaml
 	mkdir -p "${OPENAPI_OUTPUT_DIR}"
 	python tools/transform_nethsm_api_spec.py nethsm-api.yaml "${OPENAPI_OUTPUT_DIR}/nethsm-api.json"
 	docker run --rm -ti -v "${OPENAPI_OUTPUT_DIR}:/out" \
-		openapijsonschematools/openapi-json-schema-generator-cli:latest generate \
+		openapijsonschematools/openapi-json-schema-generator-cli:3.1.0 generate \
 		-i=/out/nethsm-api.json \
 		-g=python -o=/out/python --package-name=nethsm.client
 	cp -r "${OPENAPI_OUTPUT_DIR}/python/src/nethsm/client" nethsm

--- a/nethsm-api.yaml
+++ b/nethsm-api.yaml
@@ -867,11 +867,9 @@ paths:
         "403":
           description: Access denied.
         "404":
-          description: Certificate with this KeyID not found.
+          description: There is no certificate for this KeyID.
         "406":
           description: Content type in Accept header not supported.
-        "409":
-          description: Certificate for key not found.
         "412":
           description: Precondition failed (NetHSM was not *Operational*).
       description: Delete the certificate.

--- a/nethsm/__init__.py
+++ b/nethsm/__init__.py
@@ -1061,10 +1061,7 @@ class NetHSM:
                 e,
                 state=State.OPERATIONAL,
                 roles=[Role.ADMINISTRATOR],
-                messages={
-                    404: f"Key {key_id} not found",
-                    409: f"Certificate for key {key_id} not found",
-                },
+                messages={404: f"There is no certificate for {key_id}."},
             )
 
     def csr(

--- a/nethsm/client/api_client.py
+++ b/nethsm/client/api_client.py
@@ -1234,8 +1234,8 @@ class Api:
                 headers.add('Accept', accept_content_type)
         return headers
 
-    @staticmethod
     def _get_fields_and_body(
+        self,
         request_body: typing.Type[RequestBody],
         body: typing.Union[schemas.INPUT_TYPES_ALL, schemas.Unset],
         content_type: str,
@@ -1250,7 +1250,7 @@ class Api:
 
         serialized_fields = None
         serialized_body = None
-        serialized_data = request_body.serialize(body, content_type)
+        serialized_data = request_body.serialize(body, content_type, configuration=self.api_client.schema_configuration)
         headers.add('Content-Type', content_type)
         if 'fields' in serialized_data:
             serialized_fields = serialized_data['fields']
@@ -1378,7 +1378,7 @@ class RequestBody(StyleFormSerializer, JSONDetector):
 
     @classmethod
     def serialize(
-        cls, in_data: schemas.INPUT_TYPES_ALL, content_type: str
+        cls, in_data: schemas.INPUT_TYPES_ALL, content_type: str, configuration: typing.Optional[schema_configuration_.SchemaConfiguration] = None
     ) -> SerializedRequestBody:
         """
         If a str is returned then the result will be assigned to data when making the request
@@ -1392,7 +1392,8 @@ class RequestBody(StyleFormSerializer, JSONDetector):
         media_type = cls.content[content_type]
         assert media_type.schema is not None
         schema = schemas.get_class(media_type.schema)
-        cast_in_data = schema.validate_base(in_data)
+        used_configuration = configuration if configuration is not None else schema_configuration_.SchemaConfiguration()
+        cast_in_data = schema.validate_base(in_data, configuration=used_configuration)
         # TODO check for and use encoding if it exists
         # and content_type is multipart or application/x-www-form-urlencoded
         if cls._content_type_is_json(content_type):

--- a/nethsm/client/paths/keys/get/operation.py
+++ b/nethsm/client/paths/keys/get/operation.py
@@ -115,7 +115,10 @@ class BaseApi(api_client.Api):
             class instances
         """
         if query_params is not None:
-            query_params = QueryParameters.validate(query_params)
+            query_params = QueryParameters.validate(
+                query_params,
+                configuration=self.api_client.schema_configuration
+            )
         used_path, query_params_suffix = self._get_used_path(
             path,
             query_parameters=query_parameter_classes,

--- a/nethsm/client/paths/keys/post/operation.py
+++ b/nethsm/client/paths/keys/post/operation.py
@@ -176,7 +176,10 @@ class BaseApi(api_client.Api):
             class instances
         """
         if query_params is not None:
-            query_params = QueryParameters.validate(query_params)
+            query_params = QueryParameters.validate(
+                query_params,
+                configuration=self.api_client.schema_configuration
+            )
         used_path, query_params_suffix = self._get_used_path(
             path,
             query_parameters=query_parameter_classes,

--- a/nethsm/client/paths/keys_key_id/delete/operation.py
+++ b/nethsm/client/paths/keys_key_id/delete/operation.py
@@ -108,7 +108,10 @@ class BaseApi(api_client.Api):
             api_response.body and api_response.headers will not be deserialized into schema
             class instances
         """
-        path_params = PathParameters.validate(path_params)
+        path_params = PathParameters.validate(
+            path_params,
+            configuration=self.api_client.schema_configuration
+        )
         used_path, query_params_suffix = self._get_used_path(
             path,
             path_parameters=path_parameter_classes,

--- a/nethsm/client/paths/keys_key_id/get/operation.py
+++ b/nethsm/client/paths/keys_key_id/get/operation.py
@@ -119,7 +119,10 @@ class BaseApi(api_client.Api):
             api_response.body and api_response.headers will not be deserialized into schema
             class instances
         """
-        path_params = PathParameters.validate(path_params)
+        path_params = PathParameters.validate(
+            path_params,
+            configuration=self.api_client.schema_configuration
+        )
         used_path, query_params_suffix = self._get_used_path(
             path,
             path_parameters=path_parameter_classes,

--- a/nethsm/client/paths/keys_key_id/put/operation.py
+++ b/nethsm/client/paths/keys_key_id/put/operation.py
@@ -204,9 +204,15 @@ class BaseApi(api_client.Api):
             api_response.body and api_response.headers will not be deserialized into schema
             class instances
         """
-        path_params = PathParameters.validate(path_params)
+        path_params = PathParameters.validate(
+            path_params,
+            configuration=self.api_client.schema_configuration
+        )
         if query_params is not None:
-            query_params = QueryParameters.validate(query_params)
+            query_params = QueryParameters.validate(
+                query_params,
+                configuration=self.api_client.schema_configuration
+            )
         used_path, query_params_suffix = self._get_used_path(
             path,
             path_parameters=path_parameter_classes,

--- a/nethsm/client/paths/keys_key_id_cert/delete/operation.py
+++ b/nethsm/client/paths/keys_key_id_cert/delete/operation.py
@@ -14,7 +14,6 @@ from .responses import (
     response_403,
     response_404,
     response_406,
-    response_409,
     response_412,
 )
 from .parameters import parameter_0
@@ -37,7 +36,6 @@ __StatusCodeToResponse = typing.TypedDict(
         '403': typing.Type[response_403.ResponseFor403],
         '404': typing.Type[response_404.ResponseFor404],
         '406': typing.Type[response_406.ResponseFor406],
-        '409': typing.Type[response_409.ResponseFor409],
         '412': typing.Type[response_412.ResponseFor412],
     }
 )
@@ -47,7 +45,6 @@ _status_code_to_response: __StatusCodeToResponse = {
     '403': response_403.ResponseFor403,
     '404': response_404.ResponseFor404,
     '406': response_406.ResponseFor406,
-    '409': response_409.ResponseFor409,
     '412': response_412.ResponseFor412,
 }
 _non_error_status_codes = frozenset({
@@ -58,7 +55,6 @@ _error_status_codes = frozenset({
     '403',
     '404',
     '406',
-    '409',
     '412',
 })
 
@@ -112,7 +108,10 @@ class BaseApi(api_client.Api):
             api_response.body and api_response.headers will not be deserialized into schema
             class instances
         """
-        path_params = PathParameters.validate(path_params)
+        path_params = PathParameters.validate(
+            path_params,
+            configuration=self.api_client.schema_configuration
+        )
         used_path, query_params_suffix = self._get_used_path(
             path,
             path_parameters=path_parameter_classes,
@@ -160,7 +159,6 @@ class BaseApi(api_client.Api):
                     '403',
                     '404',
                     '406',
-                    '409',
                     '412',
                 ],
                 status

--- a/nethsm/client/paths/keys_key_id_cert/get/operation.py
+++ b/nethsm/client/paths/keys_key_id_cert/get/operation.py
@@ -121,7 +121,10 @@ class BaseApi(api_client.Api):
             api_response.body and api_response.headers will not be deserialized into schema
             class instances
         """
-        path_params = PathParameters.validate(path_params)
+        path_params = PathParameters.validate(
+            path_params,
+            configuration=self.api_client.schema_configuration
+        )
         used_path, query_params_suffix = self._get_used_path(
             path,
             path_parameters=path_parameter_classes,

--- a/nethsm/client/paths/keys_key_id_cert/put/operation.py
+++ b/nethsm/client/paths/keys_key_id_cert/put/operation.py
@@ -194,7 +194,10 @@ class BaseApi(api_client.Api):
             api_response.body and api_response.headers will not be deserialized into schema
             class instances
         """
-        path_params = PathParameters.validate(path_params)
+        path_params = PathParameters.validate(
+            path_params,
+            configuration=self.api_client.schema_configuration
+        )
         used_path, query_params_suffix = self._get_used_path(
             path,
             path_parameters=path_parameter_classes,

--- a/nethsm/client/paths/keys_key_id_csr_pem/post/operation.py
+++ b/nethsm/client/paths/keys_key_id_csr_pem/post/operation.py
@@ -136,7 +136,10 @@ class BaseApi(api_client.Api):
             api_response.body and api_response.headers will not be deserialized into schema
             class instances
         """
-        path_params = PathParameters.validate(path_params)
+        path_params = PathParameters.validate(
+            path_params,
+            configuration=self.api_client.schema_configuration
+        )
         used_path, query_params_suffix = self._get_used_path(
             path,
             path_parameters=path_parameter_classes,

--- a/nethsm/client/paths/keys_key_id_decrypt/post/operation.py
+++ b/nethsm/client/paths/keys_key_id_decrypt/post/operation.py
@@ -136,7 +136,10 @@ class BaseApi(api_client.Api):
             api_response.body and api_response.headers will not be deserialized into schema
             class instances
         """
-        path_params = PathParameters.validate(path_params)
+        path_params = PathParameters.validate(
+            path_params,
+            configuration=self.api_client.schema_configuration
+        )
         used_path, query_params_suffix = self._get_used_path(
             path,
             path_parameters=path_parameter_classes,

--- a/nethsm/client/paths/keys_key_id_encrypt/post/operation.py
+++ b/nethsm/client/paths/keys_key_id_encrypt/post/operation.py
@@ -136,7 +136,10 @@ class BaseApi(api_client.Api):
             api_response.body and api_response.headers will not be deserialized into schema
             class instances
         """
-        path_params = PathParameters.validate(path_params)
+        path_params = PathParameters.validate(
+            path_params,
+            configuration=self.api_client.schema_configuration
+        )
         used_path, query_params_suffix = self._get_used_path(
             path,
             path_parameters=path_parameter_classes,

--- a/nethsm/client/paths/keys_key_id_public_pem/get/operation.py
+++ b/nethsm/client/paths/keys_key_id_public_pem/get/operation.py
@@ -119,7 +119,10 @@ class BaseApi(api_client.Api):
             api_response.body and api_response.headers will not be deserialized into schema
             class instances
         """
-        path_params = PathParameters.validate(path_params)
+        path_params = PathParameters.validate(
+            path_params,
+            configuration=self.api_client.schema_configuration
+        )
         used_path, query_params_suffix = self._get_used_path(
             path,
             path_parameters=path_parameter_classes,

--- a/nethsm/client/paths/keys_key_id_restrictions_tags_tag/delete/operation.py
+++ b/nethsm/client/paths/keys_key_id_restrictions_tags_tag/delete/operation.py
@@ -112,7 +112,10 @@ class BaseApi(api_client.Api):
             api_response.body and api_response.headers will not be deserialized into schema
             class instances
         """
-        path_params = PathParameters.validate(path_params)
+        path_params = PathParameters.validate(
+            path_params,
+            configuration=self.api_client.schema_configuration
+        )
         used_path, query_params_suffix = self._get_used_path(
             path,
             path_parameters=path_parameter_classes,

--- a/nethsm/client/paths/keys_key_id_restrictions_tags_tag/put/operation.py
+++ b/nethsm/client/paths/keys_key_id_restrictions_tags_tag/put/operation.py
@@ -123,7 +123,10 @@ class BaseApi(api_client.Api):
             api_response.body and api_response.headers will not be deserialized into schema
             class instances
         """
-        path_params = PathParameters.validate(path_params)
+        path_params = PathParameters.validate(
+            path_params,
+            configuration=self.api_client.schema_configuration
+        )
         used_path, query_params_suffix = self._get_used_path(
             path,
             path_parameters=path_parameter_classes,

--- a/nethsm/client/paths/keys_key_id_sign/post/operation.py
+++ b/nethsm/client/paths/keys_key_id_sign/post/operation.py
@@ -136,7 +136,10 @@ class BaseApi(api_client.Api):
             api_response.body and api_response.headers will not be deserialized into schema
             class instances
         """
-        path_params = PathParameters.validate(path_params)
+        path_params = PathParameters.validate(
+            path_params,
+            configuration=self.api_client.schema_configuration
+        )
         used_path, query_params_suffix = self._get_used_path(
             path,
             path_parameters=path_parameter_classes,

--- a/nethsm/client/paths/system_restore/post/operation.py
+++ b/nethsm/client/paths/system_restore/post/operation.py
@@ -119,7 +119,10 @@ class BaseApi(api_client.Api):
             api_response.body and api_response.headers will not be deserialized into schema
             class instances
         """
-        query_params = QueryParameters.validate(query_params)
+        query_params = QueryParameters.validate(
+            query_params,
+            configuration=self.api_client.schema_configuration
+        )
         used_path, query_params_suffix = self._get_used_path(
             path,
             query_parameters=query_parameter_classes,

--- a/nethsm/client/paths/users_user_id/delete/operation.py
+++ b/nethsm/client/paths/users_user_id/delete/operation.py
@@ -108,7 +108,10 @@ class BaseApi(api_client.Api):
             api_response.body and api_response.headers will not be deserialized into schema
             class instances
         """
-        path_params = PathParameters.validate(path_params)
+        path_params = PathParameters.validate(
+            path_params,
+            configuration=self.api_client.schema_configuration
+        )
         used_path, query_params_suffix = self._get_used_path(
             path,
             path_parameters=path_parameter_classes,

--- a/nethsm/client/paths/users_user_id/get/operation.py
+++ b/nethsm/client/paths/users_user_id/get/operation.py
@@ -119,7 +119,10 @@ class BaseApi(api_client.Api):
             api_response.body and api_response.headers will not be deserialized into schema
             class instances
         """
-        path_params = PathParameters.validate(path_params)
+        path_params = PathParameters.validate(
+            path_params,
+            configuration=self.api_client.schema_configuration
+        )
         used_path, query_params_suffix = self._get_used_path(
             path,
             path_parameters=path_parameter_classes,

--- a/nethsm/client/paths/users_user_id/put/operation.py
+++ b/nethsm/client/paths/users_user_id/put/operation.py
@@ -129,7 +129,10 @@ class BaseApi(api_client.Api):
             api_response.body and api_response.headers will not be deserialized into schema
             class instances
         """
-        path_params = PathParameters.validate(path_params)
+        path_params = PathParameters.validate(
+            path_params,
+            configuration=self.api_client.schema_configuration
+        )
         used_path, query_params_suffix = self._get_used_path(
             path,
             path_parameters=path_parameter_classes,

--- a/nethsm/client/paths/users_user_id_passphrase/post/operation.py
+++ b/nethsm/client/paths/users_user_id_passphrase/post/operation.py
@@ -129,7 +129,10 @@ class BaseApi(api_client.Api):
             api_response.body and api_response.headers will not be deserialized into schema
             class instances
         """
-        path_params = PathParameters.validate(path_params)
+        path_params = PathParameters.validate(
+            path_params,
+            configuration=self.api_client.schema_configuration
+        )
         used_path, query_params_suffix = self._get_used_path(
             path,
             path_parameters=path_parameter_classes,

--- a/nethsm/client/paths/users_user_id_tags/get/operation.py
+++ b/nethsm/client/paths/users_user_id_tags/get/operation.py
@@ -119,7 +119,10 @@ class BaseApi(api_client.Api):
             api_response.body and api_response.headers will not be deserialized into schema
             class instances
         """
-        path_params = PathParameters.validate(path_params)
+        path_params = PathParameters.validate(
+            path_params,
+            configuration=self.api_client.schema_configuration
+        )
         used_path, query_params_suffix = self._get_used_path(
             path,
             path_parameters=path_parameter_classes,

--- a/nethsm/client/paths/users_user_id_tags_tag/delete/operation.py
+++ b/nethsm/client/paths/users_user_id_tags_tag/delete/operation.py
@@ -112,7 +112,10 @@ class BaseApi(api_client.Api):
             api_response.body and api_response.headers will not be deserialized into schema
             class instances
         """
-        path_params = PathParameters.validate(path_params)
+        path_params = PathParameters.validate(
+            path_params,
+            configuration=self.api_client.schema_configuration
+        )
         used_path, query_params_suffix = self._get_used_path(
             path,
             path_parameters=path_parameter_classes,

--- a/nethsm/client/paths/users_user_id_tags_tag/put/operation.py
+++ b/nethsm/client/paths/users_user_id_tags_tag/put/operation.py
@@ -123,7 +123,10 @@ class BaseApi(api_client.Api):
             api_response.body and api_response.headers will not be deserialized into schema
             class instances
         """
-        path_params = PathParameters.validate(path_params)
+        path_params = PathParameters.validate(
+            path_params,
+            configuration=self.api_client.schema_configuration
+        )
         used_path, query_params_suffix = self._get_used_path(
             path,
             path_parameters=path_parameter_classes,

--- a/nethsm/client/schemas/validation.py
+++ b/nethsm/client/schemas/validation.py
@@ -99,6 +99,14 @@ class SchemaValidator:
                 validation_metadata,
                 path_to_schemas
             )
+        validated_pattern_properties: typing.Optional[PathToSchemasType] = None
+        if 'pattern_properties' in vars(cls_schema):
+             validated_pattern_properties = _get_validated_pattern_properties(
+                 arg,
+                 vars(cls_schema)['pattern_properties'],
+                 cls,
+                 validation_metadata
+             )
         prefix_items_length = 0
         if 'prefix_items' in vars(cls_schema):
             prefix_items_length = len(vars(cls_schema)['prefix_items'])
@@ -110,6 +118,11 @@ class SchemaValidator:
                 used_val = (val, prefix_items_length)
             elif keyword in {'unevaluated_items', 'unevaluated_properties'}:
                 used_val = (val, path_to_schemas)
+            elif keyword in {'types'}:
+                format: typing.Optional[str] = vars(cls_schema).get('format', None)
+                used_val = (val, format)
+            elif keyword in {'pattern_properties', 'additional_properties'}:
+                used_val = (val, validated_pattern_properties)
             else:
                 used_val = val
             validator = json_schema_keyword_to_validator[keyword]
@@ -257,10 +270,11 @@ class PatternInfo:
 
 def validate_types(
     arg: typing.Any,
-    allowed_types: typing.Set[typing.Type],
+    allowed_types_format: typing.Tuple[typing.Set[typing.Type], typing.Optional[str]],
     cls: typing.Type,
     validation_metadata: ValidationMetadata,
 ) -> None:
+    allowed_types = allowed_types_format[0]
     if type(arg) not in allowed_types:
         raise __get_type_error(
             arg,
@@ -268,7 +282,18 @@ def validate_types(
             allowed_types,
             key_type=False,
         )
+    if isinstance(arg, bool) or not isinstance(arg, (int, float)):
+        return None
+    format = allowed_types_format[1]
+    if format and format == 'int' and arg != int(arg):
+        # there is a json schema test where 1.0 validates as an integer
+        raise exceptions.ApiValueError(
+            "Invalid non-integer value '{}' for type {} at {}".format(
+                arg, format, validation_metadata.path_to_item
+            )
+        )
     return None
+
 
 def validate_enum(
     arg: typing.Any,
@@ -722,19 +747,25 @@ def validate_properties(
 
 def validate_additional_properties(
     arg: typing.Any,
-    additional_properties_cls: typing.Type[SchemaValidator],
+    additional_properties_cls_val_pprops: typing.Tuple[
+        typing.Type[SchemaValidator],
+        typing.Optional[PathToSchemasType]
+    ],
     cls: typing.Type,
     validation_metadata: ValidationMetadata,
 ) -> typing.Optional[PathToSchemasType]:
     if not isinstance(arg, immutabledict):
         return None
-    schema = _get_class(additional_properties_cls)
+    schema = _get_class(additional_properties_cls_val_pprops[0])
     path_to_schemas: PathToSchemasType = {}
     cls_schema = cls()
     properties = cls_schema.properties if hasattr(cls_schema, 'properties') else {}
     present_additional_properties = {k: v for k, v, in arg.items() if k not in properties}
+    validated_pattern_properties = additional_properties_cls_val_pprops[1]
     for property_name, value in present_additional_properties.items():
         path_to_item = validation_metadata.path_to_item + (property_name,)
+        if validated_pattern_properties and path_to_item in validated_pattern_properties:
+            continue
         arg_validation_metadata = ValidationMetadata(
             path_to_item=path_to_item,
             configuration=validation_metadata.configuration,
@@ -1133,7 +1164,7 @@ def validate_property_names(
     return None
 
 
-def validate_pattern_properties(
+def _get_validated_pattern_properties(
     arg: typing.Any,
     pattern_properties: typing.Mapping[PatternInfo, typing.Type[SchemaValidator]],
     cls: typing.Type,
@@ -1161,6 +1192,21 @@ def validate_pattern_properties(
             other_path_to_schemas = schema._validate(property_value, validation_metadata=property_validation_metadata)
             update(path_to_schemas, other_path_to_schemas)
     return path_to_schemas
+
+
+def validate_pattern_properties(
+    arg: typing.Any,
+    pattern_properties_validation_results: typing.Tuple[
+        typing.Mapping[PatternInfo, typing.Type[SchemaValidator]],
+        typing.Optional[PathToSchemasType]
+    ],
+    cls: typing.Type,
+    validation_metadata: ValidationMetadata,
+) -> typing.Optional[PathToSchemasType]:
+    if not isinstance(arg, immutabledict):
+        return None
+    validation_results = pattern_properties_validation_results[1]
+    return validation_results
 
 
 def validate_prefix_items(

--- a/tests/test_nethsm_config.py
+++ b/tests/test_nethsm_config.py
@@ -31,14 +31,16 @@ def get_config_network(nethsm):
 
 
 def get_config_time(nethsm):
-    dt_nethsm = datetime.datetime.strptime(nethsm.get_config_time(), "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=datetime.timezone.utc)
+    dt_nethsm = datetime.datetime.strptime(
+        nethsm.get_config_time(), "%Y-%m-%dT%H:%M:%SZ"
+    ).replace(tzinfo=datetime.timezone.utc)
     dt_now = datetime.datetime.now(datetime.timezone.utc)
 
     seconds_diff = (dt_nethsm - dt_now).total_seconds()
 
-    #Magic Constant 2.0
-    #Due to network latency and execution time, the time difference may vary.
-    #Therefore the time check allows a delta of nearly 2.0 seconds.
+    # Magic Constant 2.0
+    # Due to network latency and execution time, the time difference may vary.
+    # Therefore the time check allows a delta of nearly 2.0 seconds.
 
     assert abs(seconds_diff) < 2.0
 


### PR DESCRIPTION
Adjust the SDK to the updated API specification.

The update changed the HTTP status code and the error message when trying to delete a certificate which does not exist.