### PR TITLE
Extend backup/restore tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ backupNethsm.bin
 .mypy_cache
 .coverage
 coverage.xml
+encrypted.bin

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,7 @@ class Constants:
     FILENAME_BACKUP = "backupNethsm.bin"
     FILENAME_UPDATE = "update.img.bin"
     FILENAME_UPDATE_IN_TEST = "tests/update.img.bin"
+    FILENAME_ENCRYPTED = "encrypted.bin"
 
     # test_nethsm_config
     COUNTRY = "DE"


### PR DESCRIPTION
This patch enables the restore test case and extends both the backup and restore tests so that a key is generated, data is encrypted for the key before the backup is created and then decrypted after the backup has been restored.  It also adds a test to make sure that the factory reset clears the generated key.

Fixes: https://github.com/Nitrokey/nethsm-sdk-py/issues/48
