### PR TITLE
Fix return type for get_key_certificate

### DIFF
--- a/nethsm/__init__.py
+++ b/nethsm/__init__.py
@@ -987,7 +987,7 @@ class NetHSM:
             _handle_exception(e, state=State.OPERATIONAL, roles=[Role.ADMINISTRATOR])
         return response.response.data.decode("utf-8")
 
-    def get_key_certificate(self, key_id: str) -> str:
+    def get_key_certificate(self, key_id: str) -> bytes:
         try:
             from .client.paths.keys_key_id_cert.get.path_parameters import (
                 PathParametersDict,
@@ -1009,7 +1009,7 @@ class NetHSM:
                     406: f"Certificate for key {key_id} not found",
                 },
             )
-        return response.response.data.decode("utf-8")
+        return response.response.data
 
     def set_certificate(self, cert: BufferedReader) -> None:
         try:

--- a/tests/test_nethsm_keys.py
+++ b/tests/test_nethsm_keys.py
@@ -222,7 +222,7 @@ def test_set_get_key_certificate(nethsm: nethsm_module.NetHSM):
         nethsm.set_key_certificate(C.KEY_ID_ADDED, f)
     with open(C.CERTIFICATE_FILE, "rb") as f:
         certificate = nethsm.get_key_certificate(C.KEY_ID_ADDED)
-        file_cert = f.read().decode("utf-8")
+        file_cert = f.read()
         assert certificate == file_cert
 
 


### PR DESCRIPTION
https://github.com/Nitrokey/nethsm-sdk-py/pull/60 changed GET /keys/{KeyId}/cert to return bytes instead of a string, but get_key_certificate was not updated accordingly.