### PR TITLE
Pass old passphrase when setting unlock or backup passphrase

### DIFF
--- a/nethsm-api.yaml
+++ b/nethsm-api.yaml
@@ -121,7 +121,12 @@ paths:
           description: Content type in Accept header not supported.
         "412":
           description: Precondition failed (NetHSM was not *Unprovisioned*).
-      description: Initial provisioning, only available in *Unprovisioned* state.
+      description: |-
+        Initial provisioning, only available in *Unprovisioned* state.
+
+        *WARNING:* The unlock passphrase can't be reset by an admin user without
+        knowing the current value, so if the unlock passphrase is lost, neither
+        can it be reset to a new value nor can the NetHSM be unlocked.
       requestBody:
         content:
           application/json:
@@ -999,7 +1004,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/UserData"
-        
+
         "400":
           description: Invalid character in the UserID.
         "401":
@@ -1230,7 +1235,12 @@ paths:
           description: Content type in Accept header not supported.
         "412":
           description: Precondition failed (NetHSM was not *Operational*).
-      description: Update the unlock passphrase.
+      description: |-
+        Update the unlock passphrase.
+
+        *WARNING:* The unlock passphrase can't be reset by an admin user without
+        knowing the current value, so if the unlock passphrase is lost, neither
+        can it be reset to a new value nor can the NetHSM be unlocked.
       requestBody:
         content:
           application/json:
@@ -1549,7 +1559,14 @@ paths:
           description: Content type in Accept header not supported.
         "412":
           description: Precondition failed (NetHSM was not *Operational*).
-      description: Update the backup passphrase.
+      description: |-
+        Update the backup passphrase. If the backup passphrase is not set yet,
+        use "" as currentPassphrase.
+
+        *WARNING:* Like the unlock passphrase, this configuration can't be reset
+        by an admin user without knowing the current value, so if the backup
+        passphrase is lost, neither can it be reset to a new value nor can the
+        created backups be restored.
       requestBody:
         content:
           application/json:
@@ -1845,7 +1862,7 @@ paths:
 components:
   schemas:
     Passphrase:
-      minLength: 1
+      minLength: 10
       type: string
     ID:
       pattern: ^[a-zA-Z0-9]+$
@@ -2330,13 +2347,17 @@ components:
         - passphrase
     UnlockPassphraseConfig:
       example:
-        passphrase: This is my unlock passphrase
+        newPassphrase: This is my new unlock passphrase
+        currentPassphrase: UnlockPassphrase
       type: object
       properties:
-        passphrase:
+        newPassphrase:
           $ref: "#/components/schemas/Passphrase"
+        currentPassphrase:
+          type: string
       required:
-        - passphrase
+        - newPassphrase
+        - currentPassphrase
     UnattendedBootConfig:
       example:
         status: "off"
@@ -2382,13 +2403,17 @@ components:
         - logLevel
     BackupPassphraseConfig:
       example:
-        passphrase: This is my backup passphrase
+        newPassphrase: This is my new backup passphrase
+        currentPassphrase: backupPassphrase
       type: object
       properties:
-        passphrase:
+        newPassphrase:
           $ref: "#/components/schemas/Passphrase"
+        currentPassphrase:
+          type: string
       required:
-        - passphrase
+        - newPassphrase
+        - currentPassphrase
     TimeConfig:
       example:
         time: "2018-10-30T11:20:50Z"

--- a/nethsm/__init__.py
+++ b/nethsm/__init__.py
@@ -1159,12 +1159,16 @@ class NetHSM:
             )
         return response.response.data.decode("utf-8")
 
-    def set_backup_passphrase(self, passphrase: str) -> None:
+    def set_backup_passphrase(
+        self, new_passphrase: str, current_passphrase: Optional[str] = None
+    ) -> None:
         from .client.components.schema.backup_passphrase_config import (
             BackupPassphraseConfigDict,
         )
 
-        body = BackupPassphraseConfigDict(passphrase=passphrase)
+        body = BackupPassphraseConfigDict(
+            newPassphrase=new_passphrase, currentPassphrase=current_passphrase or ""
+        )
         try:
             self.get_api().config_backup_passphrase_put(body=body)
         except Exception as e:
@@ -1177,12 +1181,16 @@ class NetHSM:
                 },
             )
 
-    def set_unlock_passphrase(self, passphrase: str) -> None:
+    def set_unlock_passphrase(
+        self, new_passphrase: str, current_passphrase: str
+    ) -> None:
         from .client.components.schema.unlock_passphrase_config import (
             UnlockPassphraseConfigDict,
         )
 
-        body = UnlockPassphraseConfigDict(passphrase=passphrase)
+        body = UnlockPassphraseConfigDict(
+            newPassphrase=new_passphrase, currentPassphrase=current_passphrase
+        )
         try:
             self.get_api().config_unlock_passphrase_put(body=body)
         except Exception as e:

--- a/nethsm/client/components/schema/backup_passphrase_config.py
+++ b/nethsm/client/components/schema/backup_passphrase_config.py
@@ -10,12 +10,14 @@
 from __future__ import annotations
 from nethsm.client.shared_imports.schema_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
+CurrentPassphrase: typing_extensions.TypeAlias = schemas.StrSchema
 
 from nethsm.client.components.schema import passphrase
 Properties = typing.TypedDict(
     'Properties',
     {
-        "passphrase": typing.Type[passphrase.Passphrase],
+        "newPassphrase": typing.Type[passphrase.Passphrase],
+        "currentPassphrase": typing.Type[CurrentPassphrase],
     }
 )
 
@@ -23,7 +25,8 @@ Properties = typing.TypedDict(
 class BackupPassphraseConfigDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
-        "passphrase",
+        "currentPassphrase",
+        "newPassphrase",
     })
     __optional_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -31,12 +34,14 @@ class BackupPassphraseConfigDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_
     def __new__(
         cls,
         *,
-        passphrase: str,
+        currentPassphrase: str,
+        newPassphrase: str,
         configuration_: typing.Optional[schema_configuration.SchemaConfiguration] = None,
         **kwargs: schemas.INPUT_TYPES_ALL,
     ):
         arg_: typing.Dict[str, typing.Any] = {
-            "passphrase": passphrase,
+            "currentPassphrase": currentPassphrase,
+            "newPassphrase": newPassphrase,
         }
         arg_.update(kwargs)
         used_arg_ = typing.cast(BackupPassphraseConfigDictInput, arg_)
@@ -53,10 +58,17 @@ class BackupPassphraseConfigDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_
         return BackupPassphraseConfig.validate(arg, configuration=configuration)
     
     @property
-    def passphrase(self) -> str:
+    def currentPassphrase(self) -> str:
         return typing.cast(
             str,
-            self.__getitem__("passphrase")
+            self.__getitem__("currentPassphrase")
+        )
+    
+    @property
+    def newPassphrase(self) -> str:
+        return typing.cast(
+            str,
+            self.__getitem__("newPassphrase")
         )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
@@ -76,7 +88,8 @@ class BackupPassphraseConfig(
     """
     types: typing.FrozenSet[typing.Type] = frozenset({schemas.immutabledict})
     required: typing.FrozenSet[str] = frozenset({
-        "passphrase",
+        "currentPassphrase",
+        "newPassphrase",
     })
     properties: Properties = dataclasses.field(default_factory=lambda: schemas.typed_dict_to_instance(Properties)) # type: ignore
     type_to_output_cls: typing.Mapping[

--- a/nethsm/client/components/schema/passphrase.py
+++ b/nethsm/client/components/schema/passphrase.py
@@ -24,4 +24,4 @@ class Passphrase(
     types: typing.FrozenSet[typing.Type] = frozenset({
         str,
     })
-    min_length: int = 1
+    min_length: int = 10

--- a/nethsm/client/components/schema/unlock_passphrase_config.py
+++ b/nethsm/client/components/schema/unlock_passphrase_config.py
@@ -10,12 +10,14 @@
 from __future__ import annotations
 from nethsm.client.shared_imports.schema_imports import *  # pyright: ignore [reportWildcardImportFromLibrary]
 
+CurrentPassphrase: typing_extensions.TypeAlias = schemas.StrSchema
 
 from nethsm.client.components.schema import passphrase
 Properties = typing.TypedDict(
     'Properties',
     {
-        "passphrase": typing.Type[passphrase.Passphrase],
+        "newPassphrase": typing.Type[passphrase.Passphrase],
+        "currentPassphrase": typing.Type[CurrentPassphrase],
     }
 )
 
@@ -23,7 +25,8 @@ Properties = typing.TypedDict(
 class UnlockPassphraseConfigDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_TYPES]):
 
     __required_keys__: typing.FrozenSet[str] = frozenset({
-        "passphrase",
+        "currentPassphrase",
+        "newPassphrase",
     })
     __optional_keys__: typing.FrozenSet[str] = frozenset({
     })
@@ -31,12 +34,14 @@ class UnlockPassphraseConfigDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_
     def __new__(
         cls,
         *,
-        passphrase: str,
+        currentPassphrase: str,
+        newPassphrase: str,
         configuration_: typing.Optional[schema_configuration.SchemaConfiguration] = None,
         **kwargs: schemas.INPUT_TYPES_ALL,
     ):
         arg_: typing.Dict[str, typing.Any] = {
-            "passphrase": passphrase,
+            "currentPassphrase": currentPassphrase,
+            "newPassphrase": newPassphrase,
         }
         arg_.update(kwargs)
         used_arg_ = typing.cast(UnlockPassphraseConfigDictInput, arg_)
@@ -53,10 +58,17 @@ class UnlockPassphraseConfigDict(schemas.immutabledict[str, schemas.OUTPUT_BASE_
         return UnlockPassphraseConfig.validate(arg, configuration=configuration)
     
     @property
-    def passphrase(self) -> str:
+    def currentPassphrase(self) -> str:
         return typing.cast(
             str,
-            self.__getitem__("passphrase")
+            self.__getitem__("currentPassphrase")
+        )
+    
+    @property
+    def newPassphrase(self) -> str:
+        return typing.cast(
+            str,
+            self.__getitem__("newPassphrase")
         )
     
     def get_additional_property_(self, name: str) -> typing.Union[schemas.OUTPUT_BASE_TYPES, schemas.Unset]:
@@ -76,7 +88,8 @@ class UnlockPassphraseConfig(
     """
     types: typing.FrozenSet[typing.Type] = frozenset({schemas.immutabledict})
     required: typing.FrozenSet[str] = frozenset({
-        "passphrase",
+        "currentPassphrase",
+        "newPassphrase",
     })
     properties: Properties = dataclasses.field(default_factory=lambda: schemas.typed_dict_to_instance(Properties)) # type: ignore
     type_to_output_cls: typing.Mapping[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,7 @@ class Constants:
     PASSPHRASE_WRONG = "madmadadmin"
     PASSPHRASE_WRONG_CASE = "AdminiAdmini"
     BACKUP_PASSPHRASE = "adminadmin"
+    BACKUP_PASSPHRASE_CHANGED = "backupbackup"
 
     # test_nethsm_system
     FILENAME_BACKUP = "backupNethsm.bin"

--- a/tests/test_nethsm_config.py
+++ b/tests/test_nethsm_config.py
@@ -168,7 +168,10 @@ def test_set_backup_passphrase(nethsm):
     true only if failing. Because this test is dependant of set_backup,
     reset and restore it would be better to write an own module for that with
     a suitable fixture"""
-    nethsm.set_backup_passphrase(C.BACKUP_PASSPHRASE)
+    nethsm.set_backup_passphrase(C.BACKUP_PASSPHRASE_CHANGED)
+    nethsm.set_backup_passphrase(
+        C.BACKUP_PASSPHRASE, current_passphrase=C.BACKUP_PASSPHRASE_CHANGED
+    )
 
 
 # @pytest.mark.skip(reason="not finished yet")
@@ -236,7 +239,10 @@ def test_set_unlock_passphrase_lock_unlock(nethsm):
 
     This command requires authentication as a user with the Administrator
     role."""
-    nethsm.set_unlock_passphrase(C.UNLOCK_PASSPHRASE_CHANGED)
+
+    nethsm.set_unlock_passphrase(
+        C.UNLOCK_PASSPHRASE_CHANGED, current_passphrase=C.UNLOCK_PASSPHRASE
+    )
 
     lock(nethsm)
     unlock(nethsm, C.UNLOCK_PASSPHRASE_CHANGED)


### PR DESCRIPTION
This patch applies an API change that requires us to include the old passphrase (if set) when setting the update or backup passphrase.