### PR TITLE
Use enums instead of literals

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,21 @@ from dataclasses import dataclass
 from os import environ
 from typing import Literal
 
+from nethsm import (
+    DecryptMode,
+    KeyMechanism,
+    KeyType,
+    LogLevel,
+    Role,
+    UnattendedBootStatus,
+)
+
 
 @dataclass
 class UserData:
     user_id: str
     real_name: str
-    role: Literal["Administrator", "Operator", "Metrics", "Backup"]
+    role: Role
 
 
 class Constants:
@@ -69,24 +78,24 @@ class Constants:
     PORT = 514
     NETMASK = "255.255.255.0"
     GATEWAY = "0.0.0.0"
-    UNATTENDED_BOOT_OFF: Literal["off"] = "off"
-    UNATTENDED_BOOT_ON: Literal["on"] = "on"
-    LOG_LEVEL: Literal["info"] = "info"
+    UNATTENDED_BOOT_OFF = UnattendedBootStatus.OFF
+    UNATTENDED_BOOT_ON = UnattendedBootStatus.ON
+    LOG_LEVEL = LogLevel.INFO
 
     # test_nethsm_keys
-    TYPE: Literal["RSA"] = "RSA"
+    TYPE = KeyType.RSA
     MECHANISM = [
-        "RSA_Signature_PKCS1",
-        "RSA_Decryption_PKCS1",
-        "RSA_Signature_PSS_SHA256",
-        "RSA_Decryption_OAEP_SHA256",
+        KeyMechanism.RSA_SIGNATURE_PKCS1,
+        KeyMechanism.RSA_DECRYPTION_PKCS1,
+        KeyMechanism.RSA_SIGNATURE_PSS_SHA256,
+        KeyMechanism.RSA_DECRYPTION_OAEP_SHA256,
     ]
     LENGTH = 1024
     KEY_ID_ADDED = "KeyIdAdded"
     KEY_ID_GENERATED = "KeyIdGenerated"
     KEY_ID_AES = "KeyIdAES"
     DATA = "Test data 123456"
-    MODE: Literal["PKCS1"] = "PKCS1"
+    MODE = DecryptMode.PKCS1
     # 'PKCS1', 'PSS_MD5', 'PSS_SHA1', 'PSS_SHA224', 'PSS_SHA256', 'PSS_SHA384', 'PSS_SHA512', 'EdDSA', 'ECDSA'
     # test_nethsm_users, test_nethsm_keys
     TAG1 = "Frankfurt"
@@ -94,15 +103,17 @@ class Constants:
     TAG3 = "Teltow"
     TAGS = [TAG1, TAG2, TAG3]
 
-    ADMIN_USER = UserData(user_id="admin", real_name="admin", role="Administrator")
+    ADMIN_USER = UserData(user_id="admin", real_name="admin", role=Role.ADMINISTRATOR)
     ADMINISTRATOR_USER = UserData(
-        user_id="UIAdministrator", real_name="RNAdministrator", role="Administrator"
+        user_id="UIAdministrator", real_name="RNAdministrator", role=Role.ADMINISTRATOR
     )
     OPERATOR_USER = UserData(
-        user_id="UIOperator", real_name="RNOperator", role="Operator"
+        user_id="UIOperator", real_name="RNOperator", role=Role.OPERATOR
     )
-    METRICS_USER = UserData(user_id="UIMetrics", real_name="RNMetrics", role="Metrics")
-    BACKUP_USER = UserData(user_id="UIBackup", real_name="RNBackup", role="Backup")
+    METRICS_USER = UserData(
+        user_id="UIMetrics", real_name="RNMetrics", role=Role.METRICS
+    )
+    BACKUP_USER = UserData(user_id="UIBackup", real_name="RNBackup", role=Role.BACKUP)
 
     DETAILS = ""
     USERS_LIST = [

--- a/tests/test_nethsm_config.py
+++ b/tests/test_nethsm_config.py
@@ -6,7 +6,7 @@ from conftest import Constants as C
 from utilities import lock, nethsm, self_sign_csr, unlock  # noqa: F401
 
 import nethsm as nethsm_module
-from nethsm import NetHSM
+from nethsm import NetHSM, TlsKeyType
 
 """########## Preparation for the Tests ##########
 
@@ -21,7 +21,7 @@ def get_config_logging(nethsm: NetHSM) -> None:
     data = nethsm.get_config_logging()
     assert data.ip_address == C.IP_ADDRESS_LOGGING
     assert data.port == C.PORT
-    assert data.log_level.value == C.LOG_LEVEL
+    assert data.log_level == C.LOG_LEVEL
 
 
 def get_config_network(nethsm: NetHSM) -> None:
@@ -81,7 +81,7 @@ def test_set_certificate(nethsm: NetHSM) -> None:
 
 
 def generate_tls_key(nethsm: NetHSM) -> None:
-    nethsm.generate_tls_key("RSA", 2048)
+    nethsm.generate_tls_key(TlsKeyType.RSA, 2048)
 
 
 def test_get_config_logging(nethsm: NetHSM) -> None:
@@ -124,8 +124,8 @@ def test_get_config_unattended_boot(nethsm: NetHSM) -> None:
     role."""
     unattended_boot = nethsm.get_config_unattended_boot()
     assert (
-        str(unattended_boot) == C.UNATTENDED_BOOT_OFF
-        or str(unattended_boot) == C.UNATTENDED_BOOT_ON
+        unattended_boot == C.UNATTENDED_BOOT_OFF.value
+        or unattended_boot == C.UNATTENDED_BOOT_ON.value
     )
 
 
@@ -219,19 +219,19 @@ def test_set_get_unattended_boot(nethsm: NetHSM) -> None:
     This command requires authentication as a user with the Administrator
     role."""
     unattended_boot = nethsm.get_config_unattended_boot()
-    if str(unattended_boot) == C.UNATTENDED_BOOT_OFF:
+    if unattended_boot == C.UNATTENDED_BOOT_OFF.value:
         nethsm.set_unattended_boot(C.UNATTENDED_BOOT_ON)
-        assert str(nethsm.get_config_unattended_boot()) == C.UNATTENDED_BOOT_ON
+        assert nethsm.get_config_unattended_boot() == C.UNATTENDED_BOOT_ON.value
 
         nethsm.set_unattended_boot(C.UNATTENDED_BOOT_OFF)
-        assert str(nethsm.get_config_unattended_boot()) == C.UNATTENDED_BOOT_OFF
+        assert nethsm.get_config_unattended_boot() == C.UNATTENDED_BOOT_OFF.value
 
-    if str(unattended_boot) == C.UNATTENDED_BOOT_ON:
+    if unattended_boot == C.UNATTENDED_BOOT_ON.value:
         nethsm.set_unattended_boot(C.UNATTENDED_BOOT_OFF)
-        assert str(nethsm.get_config_unattended_boot()) == C.UNATTENDED_BOOT_OFF
+        assert nethsm.get_config_unattended_boot() == C.UNATTENDED_BOOT_OFF.value
 
         nethsm.set_unattended_boot(C.UNATTENDED_BOOT_ON)
-        assert str(nethsm.get_config_unattended_boot()) == C.UNATTENDED_BOOT_ON
+        assert nethsm.get_config_unattended_boot() == C.UNATTENDED_BOOT_ON.value
 
 
 def test_set_unlock_passphrase_lock_unlock(nethsm: NetHSM) -> None:

--- a/tests/test_nethsm_users.py
+++ b/tests/test_nethsm_users.py
@@ -76,7 +76,7 @@ def test_list_get_delete_add_users(nethsm: NetHSM) -> None:
         for i in range(len(remaining)):
             if user.user_id == remaining[i].user_id:
                 assert user.real_name == remaining[i].real_name
-                assert user.role.value == remaining[i].role
+                assert user.role.value == remaining[i].role.value
                 remaining.pop(i)
                 break
 
@@ -91,7 +91,7 @@ def test_get_user_admin(nethsm: NetHSM) -> None:
     user = nethsm.get_user(user_id=C.ADMIN_USER.user_id)
     assert user.user_id == C.ADMIN_USER.user_id
     assert user.real_name == C.ADMIN_USER.real_name
-    assert user.role.value == C.ADMIN_USER.role
+    assert user.role.value == C.ADMIN_USER.role.value
 
 
 # @pytest.mark.xfail(reason="connect() doesn't require correct passphrase yet")


### PR DESCRIPTION
Using enums makes it easier to use the functions in a typesafe way and to validate user input.

Fixes: https://github.com/Nitrokey/nethsm-sdk-py/issues/69