### PR TITLE
Support different types of bytes input

### DIFF
--- a/tests/test_nethsm_config.py
+++ b/tests/test_nethsm_config.py
@@ -74,7 +74,7 @@ def test_set_certificate(nethsm: NetHSM) -> None:
         C.EMAIL_ADDRESS,
     )
     cert = self_sign_csr(csr)
-    nethsm.set_certificate(BytesIO(cert))  # type: ignore
+    nethsm.set_certificate(cert)
 
     remote_cert = nethsm.get_certificate()
     assert cert.decode("utf-8") == remote_cert


### PR DESCRIPTION
Previously, we required bytes input as a BufferedReader.  With this patch, we also accept FileIO and bytes instances, as supported by the generated API client.

Fixes: https://github.com/Nitrokey/nethsm-sdk-py/issues/63