### PR TITLE
Return dataclasses from get_info and encrypt

### DIFF
--- a/nethsm/__init__.py
+++ b/nethsm/__init__.py
@@ -199,6 +199,12 @@ class TlsKeyType(enum.Enum):
 
 
 @dataclass
+class Info:
+    vendor: str
+    product: str
+
+
+@dataclass
 class SystemInfo:
     firmware_version: str
     software_version: str
@@ -223,6 +229,12 @@ class Key:
     modulus: Optional[str]
     public_exponent: Optional[str]
     data: Optional[str]
+
+
+@dataclass
+class EncryptionResult:
+    encrypted: str
+    iv: str
 
 
 @dataclass
@@ -716,12 +728,12 @@ class NetHSM:
                 },
             )
 
-    def get_info(self) -> tuple[str, str]:
+    def get_info(self) -> Info:
         try:
             response = self.get_api().info_get()
         except Exception as e:
             _handle_exception(e)
-        return (response.body.vendor, response.body.product)
+        return Info(vendor=response.body.vendor, product=response.body.product)
 
     def get_state(self) -> State:
         try:
@@ -1436,7 +1448,7 @@ class NetHSM:
 
     def encrypt(
         self, key_id: str, data: str, mode: EncryptMode, iv: str
-    ) -> tuple[str, str]:
+    ) -> EncryptionResult:
         from .client.components.schema.encrypt_request_data import (
             EncryptRequestDataDict,
         )
@@ -1460,7 +1472,7 @@ class NetHSM:
                     404: f"Key {key_id} not found",
                 },
             )
-        return (response.body.encrypted, response.body.iv)
+        return EncryptionResult(encrypted=response.body.encrypted, iv=response.body.iv)
 
     def decrypt(
         self,

--- a/tests/test_nethsm_keys.py
+++ b/tests/test_nethsm_keys.py
@@ -320,9 +320,10 @@ def test_encrypt_decrypt(nethsm: NetHSM) -> None:
             EncryptMode.AES_CBC,
             iv_b64,
         )
+        assert encrypted.iv == iv_b64
         decrypt = nethsm.decrypt(
             C.KEY_ID_AES,
-            encrypted[0],
+            encrypted.encrypted,
             DecryptMode.AES_CBC,
             iv_b64,
         )

--- a/tests/test_nethsm_other.py
+++ b/tests/test_nethsm_other.py
@@ -55,10 +55,10 @@ def test_state_provision(nethsm_no_provision: NetHSM) -> None:
 
 def test_info(nethsm_no_provision: NetHSM) -> None:
     """Query the vendor and product information for a NetHSM."""
-    (vendor, product) = nethsm_no_provision.get_info()
+    info = nethsm_no_provision.get_info()
     assert nethsm_no_provision.host == C.HOST
-    assert vendor == "Nitrokey GmbH"
-    assert product == "NetHSM"
+    assert info.vendor == "Nitrokey GmbH"
+    assert info.product == "NetHSM"
 
 
 def test_state_provision_add_user_metrics_get_metrics(


### PR DESCRIPTION
This patch replaces the tuples returned by get_info and encrypt with dataclasses.

Fixes: https://github.com/Nitrokey/nethsm-sdk-py/issues/80
Fixes: https://github.com/Nitrokey/nethsm-sdk-py/issues/79