### PR TITLE
Use dataclasses for add_key

### DIFF
--- a/tests/test_nethsm_keys.py
+++ b/tests/test_nethsm_keys.py
@@ -21,6 +21,7 @@ from nethsm import (
     KeyMechanism,
     KeyType,
     NetHSM,
+    RsaPrivateKey,
     RsaPublicKey,
     SignMode,
 )
@@ -51,11 +52,7 @@ def add_key(nethsm: NetHSM) -> None:
         key_id=C.KEY_ID_ADDED,
         type=C.TYPE,
         mechanisms=C.MECHANISM,
-        prime_p=p,
-        prime_q=q,
-        public_exponent=e,
-        data=C.DATA,
-        tags=[],
+        private_key=RsaPrivateKey(prime_p=p, prime_q=q, public_exponent=e),
     )
 
 


### PR DESCRIPTION
This patch introduces the RsaPrivateKey and GenericPrivateKey dataclasses for the add_key method to make it possible to enforce that exactly only one type of private key is provided using typing.

Fixes: https://github.com/Nitrokey/nethsm-sdk-py/issues/45