### PR TITLE
Always use API version from API spec

### DIFF
--- a/nethsm/__init__.py
+++ b/nethsm/__init__.py
@@ -333,7 +333,6 @@ class NetHSM:
     def __init__(
         self,
         host: str,
-        version: str,
         username: str,
         password: str,
         verify_tls: bool = True,
@@ -344,7 +343,9 @@ class NetHSM:
             SecuritySchemeInfo,
             ServerInfo,
         )
-        from .client.servers.server_0 import Server0, VariablesDict
+        from .client.servers.server_0 import Server0, VariablesDict, Version
+
+        version = Version.default
 
         self.host = host
         self.version = version
@@ -1531,12 +1532,11 @@ class NetHSM:
 @contextlib.contextmanager
 def connect(
     host: str,
-    version: str,
     username: str,
     password: str,
     verify_tls: bool = True,
 ) -> Iterator[NetHSM]:
-    nethsm = NetHSM(host, version, username, password, verify_tls)
+    nethsm = NetHSM(host, username, password, verify_tls)
     try:
         yield nethsm
     finally:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,6 @@ class Constants:
 
     # READ env variables
     HOST = environ.get("NETHSM_HOST", "127.0.0.1:8443")
-    VERSION = "v1"
     VERIFY_TLS = False
 
     USERNAME = "admin"

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -142,7 +142,7 @@ def start_nethsm() -> KeyfenderManager:
 @contextlib.contextmanager
 def connect(user: UserData) -> Iterator[NetHSM]:
     with nethsm_module.connect(
-        C.HOST, C.VERSION, user.user_id, C.PASSWORD, C.VERIFY_TLS
+        C.HOST, user.user_id, C.PASSWORD, C.VERIFY_TLS
     ) as nethsm_out:
         yield nethsm_out
 


### PR DESCRIPTION
Previously, we required the API version as input from the user.  Yet it is not realistic that this client would work with a different API version, so this patch replaces the option with the value from the API spec.

Fixes: https://github.com/Nitrokey/nethsm-sdk-py/issues/90