### PR TITLE
Make authentication optional

### DIFF
--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -22,7 +22,7 @@ from cryptography.hazmat.primitives.serialization import Encoding
 from cryptography.x509.oid import NameOID
 
 import nethsm as nethsm_module
-from nethsm import NetHSM
+from nethsm import Authentication, NetHSM
 
 
 @pytest.fixture(scope="module")
@@ -141,9 +141,8 @@ def start_nethsm() -> KeyfenderManager:
 
 @contextlib.contextmanager
 def connect(user: UserData) -> Iterator[NetHSM]:
-    with nethsm_module.connect(
-        C.HOST, user.user_id, C.PASSWORD, C.VERIFY_TLS
-    ) as nethsm_out:
+    auth = Authentication(user.user_id, C.PASSWORD)
+    with nethsm_module.connect(C.HOST, auth, C.VERIFY_TLS) as nethsm_out:
         yield nethsm_out
 
 


### PR DESCRIPTION
Not all endpoints require authentication.  Previously, it was already possible to pass None for the username and password although it was not indicated by the type annotations.  This patch adds the Authentication data class to make it easier to pass or omit these arguments and adjusts the type annotations accordingly.

It also adds a test to make sure that accessing the system state works without authentication.

Fixes: https://github.com/Nitrokey/nethsm-sdk-py/issues/68