### PR TITLE
Parse system time into datetime object

### DIFF
--- a/nethsm/__init__.py
+++ b/nethsm/__init__.py
@@ -16,7 +16,7 @@ import json
 import re
 from base64 import b64encode
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from io import BufferedReader, FileIO
 from typing import TYPE_CHECKING, Any, Iterator, Mapping, Optional, Union, cast
 from urllib.parse import urlencode
@@ -993,12 +993,15 @@ class NetHSM:
             netmask=response.body.netmask,
         )
 
-    def get_config_time(self) -> str:
+    def get_config_time(self) -> datetime:
         try:
             response = self.get_api().config_time_get()
         except Exception as e:
             _handle_exception(e, state=State.OPERATIONAL, roles=[Role.ADMINISTRATOR])
-        return response.body.time
+        # could be replaced with datetime.fromisoformat in Python 3.11 or later
+        return datetime.strptime(response.body.time, "%Y-%m-%dT%H:%M:%SZ").replace(
+            tzinfo=timezone.utc
+        )
 
     def get_config_unattended_boot(self) -> str:
         try:

--- a/tests/test_nethsm_config.py
+++ b/tests/test_nethsm_config.py
@@ -32,9 +32,7 @@ def get_config_network(nethsm: NetHSM) -> None:
 
 
 def get_config_time(nethsm: NetHSM) -> None:
-    dt_nethsm = datetime.datetime.strptime(
-        nethsm.get_config_time(), "%Y-%m-%dT%H:%M:%SZ"
-    ).replace(tzinfo=datetime.timezone.utc)
+    dt_nethsm = nethsm.get_config_time()
     dt_now = datetime.datetime.now(datetime.timezone.utc)
 
     seconds_diff = (dt_nethsm - dt_now).total_seconds()


### PR DESCRIPTION
Instead of returning the datetime as a string, parse it and return a datetime object.

See: https://github.com/Nitrokey/nethsm-sdk-py/issues/46