### PR TITLE
tests: Move container setup into fixtures

### DIFF
--- a/tests/test_nethsm_config.py
+++ b/tests/test_nethsm_config.py
@@ -3,7 +3,7 @@ from io import BytesIO
 
 import pytest
 from conftest import Constants as C
-from utilities import lock, nethsm, self_sign_csr, unlock  # noqa: F401
+from utilities import lock, self_sign_csr, unlock
 
 import nethsm as nethsm_module
 from nethsm import NetHSM, TlsKeyType

--- a/tests/test_nethsm_keys.py
+++ b/tests/test_nethsm_keys.py
@@ -3,7 +3,6 @@ from conftest import Constants as C
 from Crypto import Random
 from Crypto.Cipher import AES
 from Crypto.Hash import SHA256
-from utilities import nethsm  # noqa: F401
 from utilities import (
     add_user,
     connect,

--- a/tests/test_nethsm_other.py
+++ b/tests/test_nethsm_other.py
@@ -3,7 +3,7 @@ from typing import Iterator
 import docker  # type: ignore
 import pytest
 from conftest import Constants as C
-from utilities import add_user, connect, lock, provision, start_nethsm, unlock
+from utilities import Container, add_user, connect, lock, provision, unlock
 
 import nethsm as nethsm_sdk
 from nethsm import NetHSM
@@ -18,37 +18,25 @@ https://stackoverflow.com/questions/36530082/running-pycharm-as-root-from-launch
 
 
 @pytest.fixture(scope="module")
-def nethsm_no_provision() -> Iterator[NetHSM]:
+def nethsm_no_provision(container: Container) -> Iterator[NetHSM]:
     """Start Docker container with Nethsm image and connect to Nethsm
 
     This Pytest Fixture will run before the tests to provide the tests with
     a nethsm instance via Docker container"""
-    container = start_nethsm()
 
     with connect(C.ADMIN_USER) as nethsm:
         yield nethsm
 
-    try:
-        container.kill()
-    except docker.errors.APIError:
-        pass
-
 
 @pytest.fixture(scope="module")
-def nethsm_no_provision_no_auth() -> Iterator[NetHSM]:
+def nethsm_no_provision_no_auth(container: Container) -> Iterator[NetHSM]:
     """Start Docker container with Nethsm image and connect to Nethsm
 
     This Pytest Fixture will run before the tests to provide the tests with
     a nethsm instance via Docker container"""
-    container = start_nethsm()
 
     with nethsm_sdk.connect(C.HOST, verify_tls=C.VERIFY_TLS) as nethsm:
         yield nethsm
-
-    try:
-        container.kill()
-    except docker.errors.APIError:
-        pass
 
 
 """######################### Start of Tests #########################"""

--- a/tests/test_nethsm_other.py
+++ b/tests/test_nethsm_other.py
@@ -3,7 +3,6 @@ from typing import Iterator
 import docker  # type: ignore
 import pytest
 from conftest import Constants as C
-from utilities import nethsm  # noqa: F401
 from utilities import add_user, connect, lock, provision, start_nethsm, unlock
 
 import nethsm as nethsm_sdk

--- a/tests/test_nethsm_system.py
+++ b/tests/test_nethsm_system.py
@@ -5,12 +5,12 @@ import pytest
 from conftest import Constants as C
 from test_nethsm_keys import generate_key
 from utilities import (
+    Container,
     add_user,
     connect,
     encrypt_rsa,
     provision,
     set_backup_passphrase,
-    start_nethsm,
     update,
 )
 
@@ -73,13 +73,13 @@ def test_passphrase_add_user_retrieve_backup(nethsm: NetHSM) -> None:
             assert False
 
 
-def test_factory_reset(nethsm: NetHSM) -> None:
+def test_factory_reset(container: Container, nethsm: NetHSM) -> None:
     """Perform a factory reset for a NetHSM instance.
 
     This command requires authentication as a user with the Administrator
     role."""
     nethsm.factory_reset()
-    start_nethsm()
+    container.restart()
 
     # make sure that we really cleared the data
     assert nethsm.get_state().value == "Unprovisioned"
@@ -87,7 +87,7 @@ def test_factory_reset(nethsm: NetHSM) -> None:
     assert nethsm.list_keys() == []
 
     nethsm.factory_reset()
-    start_nethsm()
+    container.restart()
 
 
 def test_state_restore(nethsm: NetHSM) -> None:
@@ -135,24 +135,24 @@ def test_state_restore(nethsm: NetHSM) -> None:
         assert decrypt.decode().decode() == C.DATA
 
 
-def test_state_provision_update(nethsm: NetHSM) -> None:
+def test_state_provision_update(container: Container, nethsm: NetHSM) -> None:
     """Load an update to a NetHSM instance.
 
     This command requires authentication as a user with the Administrator
     role."""
-    start_nethsm()
+    container.restart()
 
     provision(nethsm)
 
     update(nethsm)
 
 
-def test_state_provision_update_cancel_update(nethsm: NetHSM) -> None:
+def test_state_provision_update_cancel_update(container: Container, nethsm: NetHSM) -> None:
     """Cancel a queued update on a NetHSM instance.
 
     This command requires authentication as a user with the Administrator
     role."""
-    start_nethsm()
+    container.restart()
 
     provision(nethsm)
 
@@ -160,12 +160,12 @@ def test_state_provision_update_cancel_update(nethsm: NetHSM) -> None:
     nethsm.cancel_update()
 
 
-def test_update_commit_update(nethsm: NetHSM) -> None:
+def test_update_commit_update(container: Container, nethsm: NetHSM) -> None:
     """Commit a queued update on a NetHSM instance.
 
     This command requires authentication as a user with the Administrator
     role."""
-    start_nethsm()
+    container.restart()
 
     provision(nethsm)
 
@@ -173,24 +173,24 @@ def test_update_commit_update(nethsm: NetHSM) -> None:
     nethsm.commit_update()
 
 
-def test_provision_reboot(nethsm: NetHSM) -> None:
+def test_provision_reboot(container: Container, nethsm: NetHSM) -> None:
     """Reboot a NetHSM instance.
 
     This command requires authentication as a user with the Administrator
     role."""
-    start_nethsm()
+    container.restart()
 
     provision(nethsm)
 
     nethsm.reboot()
 
 
-def test_provision_shutdown(nethsm: NetHSM) -> None:
+def test_provision_shutdown(container: Container, nethsm: NetHSM) -> None:
     """Shutdown a NetHSM instance.
 
     This command requires authentication as a user with the Administrator
     role."""
-    start_nethsm()
+    container.restart()
 
     provision(nethsm)
 

--- a/tests/test_nethsm_system.py
+++ b/tests/test_nethsm_system.py
@@ -4,7 +4,6 @@ import os
 import pytest
 from conftest import Constants as C
 from test_nethsm_keys import generate_key
-from utilities import nethsm  # noqa: F401
 from utilities import (
     add_user,
     connect,

--- a/tests/test_nethsm_users.py
+++ b/tests/test_nethsm_users.py
@@ -1,7 +1,6 @@
 import pytest
 from conftest import Constants as C
 from conftest import UserData
-from utilities import nethsm  # noqa: F401
 from utilities import add_user, connect
 
 import nethsm as nethsm_module

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -25,26 +25,6 @@ import nethsm as nethsm_module
 from nethsm import Authentication, Base64, NetHSM, RsaPrivateKey
 
 
-@pytest.fixture(scope="module")
-def nethsm() -> Iterator[NetHSM]:
-    """Start Docker container with Nethsm image and connect to Nethsm
-
-    This Pytest Fixture will run before the tests to provide the tests with
-    a nethsm instance via Docker container, also the first provision of the
-    NetHSM will be done in here"""
-
-    container = start_nethsm()
-
-    with connect(C.ADMIN_USER) as nethsm:
-        provision(nethsm)
-        yield nethsm
-
-    try:
-        container.kill()
-    except docker.errors.APIError:
-        pass
-
-
 class KeyfenderManager:
     def __init__(self) -> None:
         pass


### PR DESCRIPTION
This patch moves the test container setup into fixtures.  This makes it easier to reason over the control flow, it avoids redundant setup tasks (reducing the total execution time from 169 s to 109 s) and allows tests to easily trigger a container restart.