### PR TITLE
Improve check and test targets in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,4 +66,4 @@ nethsm-client: nethsm-api.yaml
 
 .PHONY: test
 test:
-	$(PYTHON3_VENV) -m pytest --cov nethsm --cov-report=xml
+	$(PYTHON3_VENV) -m pytest --cov nethsm --cov-report=xml $(PYTEST_FLAGS)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PACKAGE_NAME=nethsm
 VENV=venv
 PYTHON3=python3
 PYTHON3_VENV=venv/bin/python3
-FLAKE8_DIRS=$(PACKAGE_NAME)/
+CHECK_DIRS=$(PACKAGE_NAME)/ tests/
 
 all: init
 
@@ -10,17 +10,16 @@ init: update-venv
 
 # code checks
 check-format:
-	$(PYTHON3_VENV) -m black --check $(PACKAGE_NAME)/
+	$(PYTHON3_VENV) -m black --check $(CHECK_DIRS)
 
 check-import-sorting:
-	$(PYTHON3_VENV) -m isort --check-only $(PACKAGE_NAME)/
+	$(PYTHON3_VENV) -m isort --check-only $(CHECK_DIRS)
 
 check-style:
-	$(PYTHON3_VENV) -m flake8 $(FLAKE8_DIRS)
+	$(PYTHON3_VENV) -m flake8 $(CHECK_DIRS)
 
 check-typing:
-	@echo "Note: run semi-clean target in case this fails without any proper reason"
-	$(PYTHON3_VENV) -m mypy $(PACKAGE_NAME)/ tests/
+	$(PYTHON3_VENV) -m mypy $(CHECK_DIRS)
 
 check: check-format check-import-sorting check-style check-typing test 
 
@@ -34,8 +33,8 @@ clean: semi-clean
 
 # automatic code fixes
 fix:
-	$(PYTHON3_VENV) -m black $(BLACK_FLAGS) $(PACKAGE_NAME)/ tests/
-	$(PYTHON3_VENV) -m isort $(ISORT_FLAGS) $(PACKAGE_NAME)/ tests/
+	$(PYTHON3_VENV) -m black $(BLACK_FLAGS) $(CHECK_DIRS)
+	$(PYTHON3_VENV) -m isort $(ISORT_FLAGS) $(CHECK_DIRS)
 
 $(VENV):
 	$(PYTHON3) -m venv $(VENV)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from os import environ
-from typing import TYPE_CHECKING, Iterator, Literal
+from typing import TYPE_CHECKING, Iterator
 
 import pytest
 

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Protocol, Type
+from typing import Any, Protocol, Type
 
 import pytest
 

--- a/tests/test_nethsm_config.py
+++ b/tests/test_nethsm_config.py
@@ -1,5 +1,4 @@
 import datetime
-from io import BytesIO
 
 import pytest
 from conftest import Constants as C

--- a/tests/test_nethsm_keys.py
+++ b/tests/test_nethsm_keys.py
@@ -19,7 +19,6 @@ from nethsm import (
     KeyMechanism,
     KeyType,
     NetHSM,
-    RsaPrivateKey,
     RsaPublicKey,
     SignMode,
 )

--- a/tests/test_nethsm_other.py
+++ b/tests/test_nethsm_other.py
@@ -1,6 +1,5 @@
 from typing import Iterator
 
-import docker  # type: ignore
 import pytest
 from conftest import Constants as C
 from utilities import Container, add_user, connect, lock, provision, unlock

--- a/tests/test_nethsm_system.py
+++ b/tests/test_nethsm_system.py
@@ -1,7 +1,6 @@
 import datetime
 import os
 
-import pytest
 from conftest import Constants as C
 from test_nethsm_keys import generate_key
 from utilities import (
@@ -15,7 +14,7 @@ from utilities import (
 )
 
 from nethsm import Base64, NetHSM, NetHSMError
-from nethsm.backup import Backup, EncryptedBackup
+from nethsm.backup import EncryptedBackup
 
 """######################### Preparation for the Tests #########################
 
@@ -147,7 +146,9 @@ def test_state_provision_update(container: Container, nethsm: NetHSM) -> None:
     update(nethsm)
 
 
-def test_state_provision_update_cancel_update(container: Container, nethsm: NetHSM) -> None:
+def test_state_provision_update_cancel_update(
+    container: Container, nethsm: NetHSM
+) -> None:
     """Cancel a queued update on a NetHSM instance.
 
     This command requires authentication as a user with the Administrator

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -8,7 +8,6 @@ from typing import Iterator, Optional
 
 import docker  # type: ignore
 import podman  # type: ignore
-import pytest
 import urllib3
 from conftest import Constants as C
 from conftest import UserData
@@ -20,7 +19,6 @@ from cryptography import x509
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.serialization import Encoding
-from cryptography.x509.oid import NameOID
 
 import nethsm as nethsm_module
 from nethsm import Authentication, Base64, NetHSM, RsaPrivateKey
@@ -56,7 +54,9 @@ class Container(ABC):
 
 
 class DockerContainer(Container):
-    def __init__(self, client: docker.client.DockerClient, image: docker.models.images.Image) -> None:
+    def __init__(
+        self, client: docker.client.DockerClient, image: docker.models.images.Image
+    ) -> None:
         self.client = client
         self.image = image
         self.container = None
@@ -80,7 +80,9 @@ class DockerContainer(Container):
 
 
 class PodmanContainer(Container):
-    def __init__(self, client: podman.client.PodmanClient, image: podman.domain.images.Image) -> None:
+    def __init__(
+        self, client: podman.client.PodmanClient, image: podman.domain.images.Image
+    ) -> None:
         self.client = client
         self.image = image
         self.container = None


### PR DESCRIPTION
This patch changes the check targets to always include the tests directory and updates the test target to support a `PYTEST_FLAGS` variable.