### PR TITLE
Add ignore_whitespace option to Base64.from_encoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Support key import from PEM files ([#99](https://github.com/Nitrokey/nethsm-sdk-py/issues/99))
+- Add `ignore_whitespace` option to `Base64.from_encoded` ([#108](https://github.com/Nitrokey/nethsm-sdk-py/issues/108))
 
 [All Changes](https://github.com/Nitrokey/nethsm-sdk-py/compare/v0.5.0...HEAD)
 

--- a/Makefile
+++ b/Makefile
@@ -66,4 +66,5 @@ nethsm-client: nethsm-api.yaml
 
 .PHONY: test
 test:
+	$(PYTHON3_VENV) -m doctest nethsm/__init__.py
 	$(PYTHON3_VENV) -m pytest --cov nethsm --cov-report=xml $(PYTEST_FLAGS)


### PR DESCRIPTION
This patch makes it easy to ignore whitespace in Base64 input, e. g. generated by the base64 tool without the --wrap=0 option.

Fixes: https://github.com/Nitrokey/nethsm-sdk-py/issues/108