### PR TITLE
Remove unused pyinstaller dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,6 @@ dev = [
   "ipython",
   "isort",
   "mypy >=1.4,<1.5",
-  "pyinstaller ==5.9.0",
-  "pyinstaller-versionfile ==2.1.1; sys_platform=='win32'",
   "pytest",
   "pytest-reporter-html1",
   "docker",


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR removes the `pyinstaller` and `pyinstaller-versionfile` from the dependencies.
The dependency is not required as this is a library and no binaries are build from it directly.

## Changes
<!-- (major technical changes list) -->

- Removes `pyinstaller` and `pyinstaller-versionfile` from dependencies.

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [x] tested with Python3.9
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels
