### PR TITLE
Send authentication header for restore when authentication provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## Unreleased
 
-- 
+### Features
+
+-
+
+### Bugfixes
+
+- Fix authentication for partial restore, i.e. on an operational instance ([#124](https://github.com/Nitrokey/nethsm-sdk-py/pull/124))
 
 [All Changes](https://github.com/Nitrokey/nethsm-sdk-py/compare/v1.2.0...HEAD)
 

--- a/nethsm/__init__.py
+++ b/nethsm/__init__.py
@@ -1584,7 +1584,10 @@ class NetHSM:
                 backup_file=backup,
             )
 
-            self._get_api().system_restore_post(body)
+            if self.auth:
+                self._get_api().system_restore_post(body, security_index=1)
+            else:
+                self._get_api().system_restore_post(body)
         except Exception as e:
             _handle_exception(
                 e,


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR adds the sending of authentication headers for the restore endpoint in case they are provided. This is important for partial restore. Otherwise the restore encounters a 401 error.

## Changes
<!-- (major technical changes list) -->

- The restore endpoint adds basic authentication headers, depending on if `auth` in `class NetHSM` is set.

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [x] tested with Python3.9
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels
