### PR TITLE
Expose TPM values in system info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
--
+- Add TPM attestation keys and platform configuration registers to `SystemInfo` ([#128](https://github.com/Nitrokey/nethsm-sdk-py/pull/128))
 
 [All Changes](https://github.com/Nitrokey/nethsm-sdk-py/compare/v1.2.1...HEAD)
 

--- a/nethsm/__init__.py
+++ b/nethsm/__init__.py
@@ -19,7 +19,16 @@ from base64 import b64decode, b64encode
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from io import BufferedReader, FileIO
-from typing import TYPE_CHECKING, Any, Iterator, Mapping, NoReturn, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterator,
+    Mapping,
+    NoReturn,
+    Optional,
+    Union,
+)
 from urllib.parse import urlencode
 
 import urllib3
@@ -262,11 +271,18 @@ class Info:
 
 
 @dataclass
+class Tpm:
+    attestation_keys: Dict[str, Any]
+    platform_configuration_registers: Dict[str, Any]
+
+
+@dataclass
 class SystemInfo:
     firmware_version: str
     software_version: str
     hardware_version: str
     build_tag: str
+    tpm: Tpm
 
 
 @dataclass
@@ -1553,6 +1569,10 @@ class NetHSM:
             software_version=response.body.softwareVersion,
             hardware_version=response.body.hardwareVersion,
             build_tag=response.body.softwareBuild,
+            tpm=Tpm(
+                attestation_keys=dict(response.body.akPub),
+                platform_configuration_registers=dict(response.body.pcr),
+            ),
         )
 
     def backup(self) -> bytes:


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR adds the exposes the TPM attestation keys and platform configuration records in the system info.

## Changes
<!-- (major technical changes list) -->

- Add `attestation_keys` and `platform_configuration_registers` to `SystemInfo` class.

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [x] tested with Python3.9
- [x] signed commits
- [ ] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels
