### PR TITLE
tests: Fix typing for podman

### DIFF
--- a/.github/workflows/cd-pypi.yaml
+++ b/.github/workflows/cd-pypi.yaml
@@ -46,7 +46,7 @@ jobs:
           . venv/bin/activate
           flit build
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nitropy-pypi
           path: dist
@@ -57,7 +57,7 @@ jobs:
     needs: build
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nitropy-pypi
       - name: Checkout repository

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,7 +98,7 @@ jobs:
           . venv/bin/activate
           make test
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: backup

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -7,7 +7,7 @@ from time import sleep
 from typing import Iterator, Optional
 
 import docker  # type: ignore
-import podman  # type: ignore
+import podman
 import urllib3
 from conftest import Constants as C
 from conftest import UserData
@@ -85,16 +85,18 @@ class PodmanContainer(Container):
     ) -> None:
         self.client = client
         self.image = image
-        self.container = None
+        self.container: Optional[podman.domain.containers.Container] = None
 
     def start(self) -> None:
-        self.container = self.client.containers.run(
+        container = self.client.containers.run(
             self.image,
             "",
             ports={"8443": 8443},
             remove=True,
             detach=True,
         )
+        assert isinstance(container, podman.domain.containers.Container)
+        self.container = container
 
     def kill(self) -> None:
         if self.container:
@@ -200,6 +202,7 @@ class KeyfenderPodmanManager(KeyfenderManager):
 
         repository, tag = C.IMAGE.split(":")
         image = client.images.pull(repository, tag=tag)
+        assert isinstance(image, podman.domain.images.Image)
 
         self.client = client
         self.image = image


### PR DESCRIPTION
podman v5.1.0 added a py.typed file so we can now use its type annotations.  Unfortunately, some methods are annotated to return unions instead of using overloads based on the arguments.  Therefore we need to add some assertions to satisfy the type checker.