### PR TITLE
Add support for custom CA certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
--
+- Add support for custom CA certificates
 
 [All Changes](https://github.com/Nitrokey/nethsm-sdk-py/compare/v1.2.1...HEAD)
 

--- a/nethsm/__init__.py
+++ b/nethsm/__init__.py
@@ -223,14 +223,16 @@ class Base64:
         Base64(data='dGVzdAo=')
         >>> Base64.from_encoded(b"dGVzdAo=")
         Base64(data='dGVzdAo=')
-        >>> Base64.from_encoded("dGV zdAo=")
-        Traceback (most recent call last):
-            ...
-        ValueError: Invalid base64 data: Non-base64 digit found: dGV zdAo=
-        >>> Base64.from_encoded(b"dGV zdAo=")
-        Traceback (most recent call last):
-            ...
-        ValueError: Invalid base64 data: Non-base64 digit found: dGV zdAo=
+        >>> try:
+        ...     Base64.from_encoded("dGV zdAo=")
+        ...     assert False
+        ... except ValueError as e:
+        ...     assert "Invalid base64 data" in str(e)
+        >>> try:
+        ...     Base64.from_encoded(b"dGV zdAo=")
+        ...     assert False
+        ... except ValueError as e:
+        ...     assert "Invalid base64 data" in str(e)
         >>> Base64.from_encoded("dGV zdAo=", ignore_whitespace=True)
         Base64(data='dGVzdAo=')
         >>> Base64.from_encoded(b"dGV zdAo=", ignore_whitespace=True)

--- a/nethsm/__init__.py
+++ b/nethsm/__init__.py
@@ -449,6 +449,7 @@ class NetHSM:
         host: str,
         auth: Optional[Authentication] = None,
         verify_tls: bool = True,
+        ca_certs: Optional[str] = None,
     ) -> None:
         from .client import ApiClient, ApiConfiguration
         from .client.components.security_schemes import security_scheme_basic
@@ -481,6 +482,7 @@ class NetHSM:
         config = ApiConfiguration(
             server_info=server_config, security_scheme_info=security_info
         )
+        config.ssl_ca_cert = ca_certs  # type: ignore[assignment]
         config.verify_ssl = verify_tls
         self.client = ApiClient(configuration=config)
 

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -323,7 +323,7 @@ def self_sign_csr(csr: str) -> bytes:
     subject = parsed_csr.subject
     issuer = subject
     public_key = parsed_csr.public_key()
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     cert = (
         x509.CertificateBuilder()
         .subject_name(subject)


### PR DESCRIPTION
This PR adds support for specifying custom CA certificates instead of using the root certificates provided by `certifi`.  It also adds a test case that uses `cryptography` to set up a custom CA and sign the TLS certificate of the NetHSM container.