### PR TITLE
Relax urllib3 version requirement and release v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
--
+- Relax `urllib3` version requirement to `>= 2, <3`
 
 [All Changes](https://github.com/Nitrokey/nethsm-sdk-py/compare/v1.4.0...HEAD)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 ## Unreleased
 
+-
+
+[All Changes](https://github.com/Nitrokey/nethsm-sdk-py/compare/v1.4.1...HEAD)
+
+## [v1.4.1](https://github.com/Nitrokey/nethsm-sdk-py/releases/tag/v1.4.1) (2025-06-05)
+
 - Relax `urllib3` version requirement to `>= 2, <3`
 
-[All Changes](https://github.com/Nitrokey/nethsm-sdk-py/compare/v1.4.0...HEAD)
+[All Changes](https://github.com/Nitrokey/nethsm-sdk-py/compare/v1.4.0...v1.4.1)
 
 ## [v1.4.0](https://github.com/Nitrokey/nethsm-sdk-py/releases/tag/v1.4.0) (2025-04-25)
 

--- a/nethsm/__init__.py
+++ b/nethsm/__init__.py
@@ -8,7 +8,7 @@
 # copied, modified, or distributed except according to those terms.
 """Python Library to manage NetHSM(s)."""
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 
 import binascii
 import contextlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "cryptography >=41.0",
   "python-dateutil",
   "typing_extensions ~= 4.3.0",
-  "urllib3 >=2.0,<2.1",
+  "urllib3 >=2.0,<3",
 ]
 
 [project.urls]


### PR DESCRIPTION
urllib3 seems to follow semantic versioning so we can relax the version requirement from <2.1 to <3.  This makes it possible to pull in security fixes e. g. for https://github.com/advisories/GHSA-34jh-p97f-mpxf.