### PR TITLE
ci: Use Trusted Publishing for TestPyPI and PyPI

### DIFF
--- a/.github/workflows/cd-pypi.yaml
+++ b/.github/workflows/cd-pypi.yaml
@@ -1,33 +1,33 @@
 name: Continuous delivery - Pypi
 
 on:
+  push:
+  pull_request:
   release:
-    types: [released]
+    types: [published]
 
 env:
   FLIT_ROOT_INSTALL: 1
 
 jobs:
-  version-check:
-    name: Check versioning
+  check-package-version:
+    name: Check package version
     runs-on: ubuntu-latest
+    container: python:3.9-slim
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Check version tag format
+        uses: actions/checkout@v4
+      - name: Check package version format
+        shell: bash
         run: |
-          TAG_VERSION="${{ github.event.release.tag_name }}"
-          if [[ $TAG_VERSION =~ ^v[0-9]+.[0-9]+.[0-9]+$ ]]; then exit 0; else exit 1; fi
-      - name: Check if version tag and package version are equal
-        run: |
-          TAG_VERSION="${{ github.event.release.tag_name }}"
-          SOURCE_VERSION="$(python3 ci-scripts/get_version.py)"
-          if [ ${TAG_VERSION:1} == ${SOURCE_VERSION} ]; then exit 0; else exit 1; fi
+          PACKAGE_VERSION="$(python3 ci-scripts/get_version.py)"
+          echo "PACKAGE_VERSION = $PACKAGE_VERSION"
+          if [[ $PACKAGE_VERSION =~ ^[0-9]+.[0-9]+.[0-9]+(-rc\.[1-9])?$ ]]; then exit 0; else exit 1; fi
   build:
     name: Build
     runs-on: ubuntu-latest
     container: python:3.9-slim
-    needs: version-check
+    needs: check-package-version
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -48,33 +48,64 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: nitropy-pypi
+          name: nethsm-pypi
           path: dist
-  publish-binary:
-    name: Publish
+  publish-testpypi:
+    name: Publish to TestPyPI
     runs-on: ubuntu-latest
-    container: python:3.9-slim
     needs: build
+    if: github.event_name == 'release' || github.ref == 'refs/heads/main'
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/nethsm
+    permissions:
+      id-token: write
     steps:
-      - name: Download artifact
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: nitropy-pypi
+          name: nethsm-pypi
+          path: dist
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+  check-tag-version:
+    name: Check tag version
+    runs-on: ubuntu-latest
+    container: python:3.9-slim
+    if: github.event_name == 'release'
+    steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Install required packages
+        uses: actions/checkout@v4
+      - name: Check tag version
+        shell: bash
         run: |
-          apt update
-          apt install -y make
-      - name: Create virtual environment
-        run: |
-          python -m venv venv
-          . venv/bin/activate
-          pip install flit
-          flit install --symlink
-      - name: Prepare pypi configuration file
-        run: sed -e "s|\${passw}|${{ secrets.PYPI_TOKEN }}|" ci-scripts/pypi/.pypirc_template > ~/.pypirc
-      - name: Publish release
-        run: |
-          . venv/bin/activate
-          flit --repository pypi publish
+          VERSION_TAG="${{ github.event.release.tag_name }}"
+          PACKAGE_VERSION="$(python3 ci-scripts/get_version.py)"
+          echo "VERSION_TAG = $VERSION_TAG"
+          echo "PACKAGE_VERSION = $PACKAGE_VERSION"
+          if [ $VERSION_TAG == $PACKAGE_VERSION ]; then exit 0; else exit 1; fi
+  publish-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: [build, check-tag-version]
+    if: github.event_name == 'release'
+    environment:
+      name: pypi
+      url: https://pypi.org/p/nethsm
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: nethsm-pypi
+          path: dist
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This PR enables trusted publishing for TestPyPI and PyPI.