### PR TITLE
Always show error message returned by NetHSM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Add `NetHSM.move_key` function for changing key IDs
 - Add optional `subject_alt_names` argument for `NetHSM.csr` and `NetHSM.key_csr`
 - Add optional `prefix` argument for `NetHSM.list_keys`
+- Always show the message returned by the NetHSM as part of the error message
 
 [All Changes](https://github.com/Nitrokey/nethsm-sdk-py/compare/v1.4.1...HEAD)
 

--- a/nethsm/__init__.py
+++ b/nethsm/__init__.py
@@ -392,9 +392,7 @@ def _handle_api_exception(
 
     if e.status in messages:
         message = messages[e.status]
-        raise NetHSMError(message)
-
-    if e.status == 401 and roles:
+    elif e.status == 401 and roles:
         message = "Unauthorized -- invalid username or password"
     elif e.status == 403 and roles:
         roles_str = [role.value for role in roles]
@@ -435,7 +433,7 @@ def _handle_api_exception(
                 custom_message = e.api_response.body.message
 
         if custom_message is not None:
-            message += "\n" + custom_message
+            message += "\nNetHSM error message: " + custom_message
 
     raise NetHSMError(message)
 


### PR DESCRIPTION
Previously, we only showed the custom error message for the returned error code if there is one.  This can be confusing if the custom error message does not match the error returned by the NetHSM.  This patch always adds the NetHSM error message to the error returned by the API.