### PR TITLE
Add support for unauthenticated shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
--
+- Add support for unauthenticated shutdown.
 
 [All Changes](https://github.com/Nitrokey/nethsm-sdk-py/compare/v2.0.0...HEAD)
 

--- a/nethsm/__init__.py
+++ b/nethsm/__init__.py
@@ -1748,7 +1748,10 @@ class NetHSM:
 
     def shutdown(self) -> None:
         try:
-            self._get_api().system_shutdown_post()
+            if self.auth:
+                self._get_api().system_shutdown_post()
+            else:
+                self._get_api().system_shutdown_post(security_index=1)
         except Exception as e:
             _handle_exception(e)
 


### PR DESCRIPTION
<!-- (an executive summary of the changes, ideally in one sentence) -->
This PR adds support for unauthenticated shutdown.

NetHSM version 3.0 introduced the unauthenticated shutdown for machines in `LOCKED` and `UNPROVISIONED` mode.

## Changes
<!-- (major technical changes list) -->

- Add handling in shutdown if no authentication is passed.
- Add test for an unprovisioned NetHSM.

## Checklist

Make sure to run `make check` and `make fix` before creating a PR, otherwise the CI will fail.

- [x] tested with Python3.9
- [x] signed commits
- [x] updated documentation (e.g. parameter description, inline doc, docs.nitrokey)
- [ ] added labels
