### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,7 +87,7 @@ jobs:
           name: backup
           path: backupNethsm.bin
       - name: upload coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           files: ./coverage.xml
       - name: login to DockerHub

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,7 +92,7 @@ jobs:
           files: ./coverage.xml
       - name: login to DockerHub
         if: github.event_name == 'push' && github.ref_name == 'main'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y make
       - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.9"
       - name: Install Poetry


### PR DESCRIPTION
This PR update the following action used in the CI/CD pipelines.

- `actions/setup-python` from `v4` to `v6`
- `codecov/codecov-action` from `v3` to `v5`
- `docker/login-action` from `v3` to `v4`

